### PR TITLE
Feat: Search page api 연동

### DIFF
--- a/src/components/SearchCard.tsx
+++ b/src/components/SearchCard.tsx
@@ -17,7 +17,7 @@ const SearchCard = ({ movie }: SearchCardProps) => {
     <Link href={`detail/${movie.id}`}>
       <div className="wrapper">
         <Image
-          src={`${IMAGE_BASE_URL}${movie.poster_path}`}
+          src={`${IMAGE_BASE_URL}/${movie.poster_path}`}
           width={146}
           height={76}
           alt="image"

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,62 +1,15 @@
 import Image from 'next/image';
 import SearchCard from '@/components/SearchCard';
 import { IMovie } from '@/interfaces/interfaces';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { BASE_URL } from '@/utils/constants';
+
+const API_KEY = process.env.NEXT_PUBLIC_API_KEY;
 
 const Search = () => {
-  // TO BE DELETED
-  const dummyData = [
-    {
-      id: 502356,
-      title: 'The Super Mario Bros. Movie',
-      poster_path: '/qNBAXBIQlnOThrVvA6mA2B5ggV6.jpg',
-      backdrop_path: '/nLBRD7UPR6GjmWQp6ASAfCTaWKX.jpg',
-    },
-    {
-      id: 552688,
-      title: 'The Mother',
-      poster_path: '/vnRthEZz16Q9VWcP5homkHxyHoy.jpg',
-      backdrop_path: '/n5NSF8wZeWQHHZtuWgbRAVpqXFR.jpg',
-    },
-    {
-      id: 5023561,
-      title: 'The Super Mario Bros. Movie',
-      poster_path: '/qNBAXBIQlnOThrVvA6mA2B5ggV6.jpg',
-      backdrop_path: '/nLBRD7UPR6GjmWQp6ASAfCTaWKX.jpg',
-    },
-    {
-      id: 5526881,
-      title: 'The Mother',
-      poster_path: '/vnRthEZz16Q9VWcP5homkHxyHoy.jpg',
-      backdrop_path: '/n5NSF8wZeWQHHZtuWgbRAVpqXFR.jpg',
-    },
-    {
-      id: 5023562,
-      title: 'The Super Mario Bros. Movie',
-      poster_path: '/qNBAXBIQlnOThrVvA6mA2B5ggV6.jpg',
-      backdrop_path: '/nLBRD7UPR6GjmWQp6ASAfCTaWKX.jpg',
-    },
-    {
-      id: 5526882,
-      title: 'The Mother',
-      poster_path: '/vnRthEZz16Q9VWcP5homkHxyHoy.jpg',
-      backdrop_path: '/n5NSF8wZeWQHHZtuWgbRAVpqXFR.jpg',
-    },
-    {
-      id: 5023563,
-      title: 'The Super Mario Bros. Movie',
-      poster_path: '/qNBAXBIQlnOThrVvA6mA2B5ggV6.jpg',
-      backdrop_path: '/nLBRD7UPR6GjmWQp6ASAfCTaWKX.jpg',
-    },
-    {
-      id: 5526883,
-      title: 'The Mother',
-      poster_path: '/vnRthEZz16Q9VWcP5homkHxyHoy.jpg',
-      backdrop_path: '/n5NSF8wZeWQHHZtuWgbRAVpqXFR.jpg',
-    },
-  ];
-
-  const [inputValue, setInputValue] = useState('');
+  const [inputValue, setInputValue] = useState<string>('');
+  const [fetchPage, setFetchPage] = useState<number>(1);
+  const [movieList, setMovieList] = useState([]);
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setInputValue(e.target.value);
@@ -65,6 +18,19 @@ const Search = () => {
   const handleCloseClick = () => {
     setInputValue('');
   };
+
+  useEffect(() => {
+    const fetchMovieList = async () =>
+      await fetch(
+        inputValue
+          ? `${BASE_URL}/search/movie?api_key=${API_KEY}&query=${inputValue}&page=${fetchPage}`
+          : `${BASE_URL}/movie/popular?api_key=${API_KEY}`
+      )
+        .then((res) => res.json())
+        .then((res) => setMovieList(res.results));
+
+    fetchMovieList();
+  }, [inputValue, fetchPage]);
 
   return (
     <div className="container">
@@ -95,7 +61,7 @@ const Search = () => {
       <div className="section-result">
         <span>Top Searches</span>
         <div className="card-container">
-          {dummyData.map((movie: IMovie) => {
+          {movieList.map((movie: IMovie) => {
             return <SearchCard key={movie.id} movie={movie} />;
           })}
         </div>
@@ -158,5 +124,14 @@ const Search = () => {
     </div>
   );
 };
+
+// export async function getServerSideProps() {
+//   const { results:searchedMovies } = await (
+//     await fetch(`${BASE_URL}/search/movie?api_key=${process.env.API_KEY}&query=${inputValue}&page=${fetchPage}`)
+//   ).json();
+//   return {
+//     props: { searchedMovies },
+//   };
+// }
 
 export default Search;


### PR DESCRIPTION
## 작업 사항
- [Feat: inputValue에 따른 api 호출](https://github.com/TherapEase-CEOS/next-netflix-17th/commit/898f95151602d6b32515edcd58bbd6537423a2d7)

## 전달 사항
- `inputValue`, `fetchPage` 등 변동이 잦은 state 에 따라 api 호출이 일어나므로 클라이언트 컴포넌트로 구현했습니다. [참고](https://velog.io/@brgndy/React-Server-vs-Client-Component-in-Next.js-13-%ED%95%B4%EC%84%9D#%ED%81%B4%EB%9D%BC%EC%9D%B4%EC%96%B8%ED%8A%B8-%EC%82%AC%EC%9D%B4%EB%93%9C-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8%EB%93%A4)
  - 이 경우, rewrite를 어떻게 할지 모르겠어서 우선 api-key는 노출되는 상태입니다... 
  - `.env` 파일에 아래와 같이 추가해주시면 됩니다.
  ```
  NEXT_PUBLIC_API_KEY = api키
  ```

- `inputValue`가 비어있는 경우, 빈 리스트를 보여주는 대신 popular movies 리스트를 가져오도록 구현했습니다.