### PR TITLE
feat: 영화 상세 페이지 api 연결

### DIFF
--- a/src/components/BannerImage.tsx
+++ b/src/components/BannerImage.tsx
@@ -1,0 +1,26 @@
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import { IMAGE_BASE_URL } from '@/utils/constants';
+
+const BannerImage = ({ poster_path }: { poster_path: string }) => {
+  return (
+    <div className="wrapper">
+      <Image
+        src={`${IMAGE_BASE_URL}${poster_path}`}
+        width={375}
+        height={415}
+        alt="banner-image"
+        style={{ objectFit: 'cover' }}
+      />
+      <div className="linearGradient"></div>
+      <style jsx>{`
+        .wrapper {
+          width: 375px;
+          height: auto;
+        }
+      `}</style>
+    </div>
+  );
+};
+
+export default BannerImage;

--- a/src/components/FlatList.tsx
+++ b/src/components/FlatList.tsx
@@ -48,7 +48,7 @@ const FlatListItem = ({ item, round }: { item: IMovie; round: boolean }) => {
         src={`${IMAGE_BASE_URL}${poster_path}`}
         width={sizes[size].width}
         height={sizes[size].height}
-        alt={title}
+        alt={title || 'movie_img'}
         style={{
           objectFit: 'cover',
           borderRadius: round ? '10rem' : 0,

--- a/src/components/FlatList.tsx
+++ b/src/components/FlatList.tsx
@@ -43,7 +43,7 @@ const FlatListItem = ({ item, round }: { item: IMovie; round: boolean }) => {
     },
   };
   return (
-    <Link href={`/detail/${id}`} key={id}>
+    <Link href={`/detail/${id}?name=${title}`} key={id}>
       <Image
         src={`${IMAGE_BASE_URL}${poster_path}`}
         width={sizes[size].width}

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -3,5 +3,6 @@ export interface IMovie {
   title: string;
   poster_path: string;
   backdrop_path: string;
+  details: string;
   /*나중에 필요한 정보 더 추가하기*/
 }

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -1,8 +1,9 @@
 export interface IMovie {
   id: number;
+  name: string;
   title: string;
   poster_path: string;
   backdrop_path: string;
-  details?: string;
+  overview?: string;
   /*나중에 필요한 정보 더 추가하기*/
 }

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -1,7 +1,7 @@
 export interface IMovie {
   id: number;
-  name: string;
-  title: string;
+  name?: string;
+  title?: string;
   poster_path: string;
   backdrop_path: string;
   overview?: string;

--- a/src/interfaces/interfaces.ts
+++ b/src/interfaces/interfaces.ts
@@ -3,6 +3,6 @@ export interface IMovie {
   title: string;
   poster_path: string;
   backdrop_path: string;
-  details: string;
+  details?: string;
   /*나중에 필요한 정보 더 추가하기*/
 }

--- a/src/pages/detail/[id].tsx
+++ b/src/pages/detail/[id].tsx
@@ -1,7 +1,109 @@
 // 메인 페이지
+import BannerImage from '@/components/BannerImage';
+import { IMovie } from '@/interfaces/interfaces';
+import Image from 'next/image';
 
-const Detail = () => {
-  return <div>This is Detail page.</div>;
+const Detail = ({ params }: { params: any }) => {
+  return (
+    <div className="container">
+      <BannerImage poster_path={'/qNBAXBIQlnOThrVvA6mA2B5ggV6.jpg'} />
+
+      <button className="play-button">
+        <Image
+          src={'/icons/play_arrow.svg'}
+          width={24}
+          height={24}
+          alt="play_arrow"
+        />{' '}
+        <span className="play-button__text">Play</span>
+      </button>
+      <article>
+        <h3>Previews</h3>
+
+        <span>
+          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sit quam dui,
+          vivamus bibendum ut. A morbi mi tortor ut felis non accumsan accumsan
+          quis. Massa, id ut ipsum aliquam enim non posuere pulvinar diam.
+        </span>
+      </article>
+      <style jsx>{`
+        .container {
+          width: 100%;
+          display: flex;
+          flex-direction: column;
+          align-items: center;
+          padding: 0 32px;
+        }
+        article {
+          display: flex;
+          flex-direction: column;
+          align-items: flex-start;
+          width: 100%;
+          margin: 0;
+          padding: 0;
+        }
+        .play-button {
+          width: 100%;
+          height: 45px;
+          border: 0px;
+          outline: 0px;
+          background-color: rgb(196, 196, 196);
+          border-radius: 5.625px;
+          display: flex;
+          -webkit-box-align: center;
+          align-items: center;
+          -webkit-box-pack: center;
+          justify-content: center;
+          gap: 15px;
+          margin-top: 13px;
+          cursor: pointer;
+        }
+
+        .play-button__text {
+          font-family: 'SF Pro Display';
+          font-style: normal;
+          font-weight: 600;
+          font-size: 20.4624px;
+          line-height: 30px;
+          /* identical to box height, or 147% */
+
+          display: flex;
+          align-items: center;
+          text-align: center;
+          letter-spacing: -0.0612px;
+
+          color: #000000;
+        }
+
+        h3 {
+          font-family: 'SF Pro Display';
+          font-style: normal;
+          font-weight: 700;
+          font-size: 26.7482px;
+          line-height: 20px;
+          /* identical to box height, or 75% */
+
+          text-align: center;
+          align-self: flex-start;
+          letter-spacing: -0.0733945px;
+
+          color: #ffffff;
+        }
+        span {
+          font-family: 'SF Pro Display';
+          font-style: normal;
+          font-weight: 400;
+          font-size: 11.1409px;
+          line-height: 14px;
+          /* or 127% */
+          opacity: 0.83;
+          letter-spacing: -0.0305636px;
+          font: normal normal 400 12px/16px SFProDisplay;
+          color: rgba(255, 255, 255, 0.83);
+        }
+      `}</style>
+    </div>
+  );
 };
 
 export default Detail;

--- a/src/pages/detail/[id].tsx
+++ b/src/pages/detail/[id].tsx
@@ -3,10 +3,39 @@ import BannerImage from '@/components/BannerImage';
 import { IMovie } from '@/interfaces/interfaces';
 import Image from 'next/image';
 import { BASE_URL } from '../../utils/constants';
-
+import { useEffect } from 'react';
+import { useCallback } from 'react';
+import { useRef } from 'react';
+import { usePathname } from 'next/navigation';
+import { useRouter } from 'next/router';
 const Detail = ({ moive }: { moive: IMovie }) => {
-  const { poster_path, overview } = moive;
+  const { name, poster_path, overview } = moive;
+  const router = useRouter();
+  const { query } = router;
 
+  const youtubeId = useRef(null);
+
+  const getYoutubeLink = async () => {
+    let results = await (
+      await fetch(
+        `https://www.googleapis.com/youtube/v3/search?type=video&q=${query.name}&key=${process.env.YOUTUBE_API_KEY}`
+      )
+    ).json();
+
+    youtubeId.current = results.items[0].id.videoId;
+
+    console.log(results, youtubeId.current);
+  };
+
+  useEffect(() => {
+    getYoutubeLink();
+  }, []);
+
+  const handleClickPlayBtn = () => {
+    if (youtubeId.current) {
+      window.open(`https://www.youtube.com/watch?v=${youtubeId.current}`);
+    }
+  };
   return (
     <div className="container">
       <BannerImage poster_path={poster_path} />
@@ -17,7 +46,9 @@ const Detail = ({ moive }: { moive: IMovie }) => {
           height={24}
           alt="play_arrow"
         />{' '}
-        <span className="play-button__text">Play</span>
+        <span className="play-button__text" onClick={handleClickPlayBtn}>
+          Play
+        </span>
       </button>
       <article>
         <h3>Previews</h3>

--- a/src/pages/detail/[id].tsx
+++ b/src/pages/detail/[id].tsx
@@ -2,12 +2,14 @@
 import BannerImage from '@/components/BannerImage';
 import { IMovie } from '@/interfaces/interfaces';
 import Image from 'next/image';
+import { BASE_URL } from '../../utils/constants';
 
-const Detail = ({ params }: { params: any }) => {
+const Detail = ({ moive }: { moive: IMovie }) => {
+  const { poster_path, overview } = moive;
+
   return (
     <div className="container">
-      <BannerImage poster_path={'/qNBAXBIQlnOThrVvA6mA2B5ggV6.jpg'} />
-
+      <BannerImage poster_path={poster_path} />
       <button className="play-button">
         <Image
           src={'/icons/play_arrow.svg'}
@@ -20,11 +22,7 @@ const Detail = ({ params }: { params: any }) => {
       <article>
         <h3>Previews</h3>
 
-        <span>
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sit quam dui,
-          vivamus bibendum ut. A morbi mi tortor ut felis non accumsan accumsan
-          quis. Massa, id ut ipsum aliquam enim non posuere pulvinar diam.
-        </span>
+        <span>{overview}</span>
       </article>
       <style jsx>{`
         .container {
@@ -105,5 +103,13 @@ const Detail = ({ params }: { params: any }) => {
     </div>
   );
 };
+export const getServerSideProps = async (context: any) => {
+  const movieId = context.query.id;
 
+  let moive = await (
+    await fetch(`${BASE_URL}/movie/${movieId}?api_key=${process.env.API_KEY}`)
+  ).json();
+
+  return { props: { moive } };
+};
 export default Detail;


### PR DESCRIPTION
# 구현 상황

- 동적 라우팅을 통한 url 파라미터 ( 영화 id ) 로 특정 영화 정보를 가져옵니다. (SSR)
- Youtube search api v3 를 활용하여 특정 검색어로 검색한 영상 목록을 가져오고, 그 중 첫번째 영상으로 Play 링크를 연결합니다.
    - 관련 문서 링크 : https://developers.google.com/youtube/v3/docs/search?hl=ko
  


# 전달 사항
- 유튜브 API 적용을 위해 배포시에 .env 파일에 YOUTUBE_API_KEY 를 추가해야합니다. 
해당 Key는  카톡으로 전달드리겠습니다 😊
- 유튜브 Search API 를 활용할 때, 검색 인자로 영화 제목이 필요하여 상세 페이지로 이동할때 
name(영화제목) 이라는 추가 쿼리 파라미터를 전달하였습니다. 
- 영화 인터페이스 타입을 다음과 같이 수정하였습니다! 

```
export interface IMovie {
  id: number;
  name: string;
  title: string;
  poster_path: string;
  backdrop_path: string;
  overview?: string;
  /*나중에 필요한 정보 더 추가하기*/
}

```

